### PR TITLE
Add status target to Makefile

### DIFF
--- a/p4src/rate_limiter/Makefile
+++ b/p4src/rate_limiter/Makefile
@@ -76,3 +76,19 @@ build-p4:
 		--Wdisable=unsupported \
 		./rate_limiter/rate_limiter.p4
 	@echo "*** P4 program compiled successfully! Output files are in p4build"
+
+status:
+	@echo "GUI Status:"
+	@docker ps | grep -q "${gui_docker_name}"; \
+	if [ $$? -eq 0 ]; then \
+	  echo "  GUI is running"; \
+	else \
+	  echo "  GUI NOT running"; \
+	fi;
+	@echo "Mininet Status:"
+	@docker ps | grep -q "${mn_docker_name}"; \
+	if [ $$? -eq 0 ]; then \
+	  echo "  MININET is running"; \
+	else \
+	  echo "  MININET NOT running"; \
+	fi;


### PR DESCRIPTION
With the status target you can check if GUI and/or mininet is already running in background